### PR TITLE
Add Parity Checker, MUX, and Multiplexer Code Implementations

### DIFF
--- a/Codes to learn from/4-general stuff/mux_8x1_structural.vhd
+++ b/Codes to learn from/4-general stuff/mux_8x1_structural.vhd
@@ -1,0 +1,42 @@
+library IEEE;
+use IEEE.STD_LOGIC_1164.ALL;
+
+entity mux_8x1 is
+    Port (
+        D0, D1, D2, D3, D4, D5, D6, D7 : in STD_LOGIC_VECTOR(7 downto 0);
+        Sel : in STD_LOGIC_VECTOR(2 downto 0);
+        Y : out STD_LOGIC_VECTOR(7 downto 0)
+    );
+end mux_8x1;
+
+architecture Structural of mux_8x1 is
+
+    -- Component declaration
+    component mux_2x1
+        Port (
+            A : in STD_LOGIC_VECTOR(7 downto 0);
+            B : in STD_LOGIC_VECTOR(7 downto 0);
+            Sel : in STD_LOGIC;
+            Y : out STD_LOGIC_VECTOR(7 downto 0)
+        );
+    end component;
+
+    -- Signals for intermediate connections
+    signal Y0, Y1, Y2, Y3 : STD_LOGIC_VECTOR(7 downto 0);
+
+begin
+
+    -- Instantiate first layer of 2×1 multiplexers
+    MUX0 : mux_2x1 Port Map (A => D0, B => D1, Sel => Sel(0), Y => Y0);
+    MUX1 : mux_2x1 Port Map (A => D2, B => D3, Sel => Sel(0), Y => Y1);
+    MUX2 : mux_2x1 Port Map (A => D4, B => D5, Sel => Sel(0), Y => Y2);
+    MUX3 : mux_2x1 Port Map (A => D6, B => D7, Sel => Sel(0), Y => Y3);
+
+    -- Instantiate second layer of 2×1 multiplexers
+    MUX4 : mux_2x1 Port Map (A => Y0, B => Y1, Sel => Sel(1), Y => Y4);
+    MUX5 : mux_2x1 Port Map (A => Y2, B => Y3, Sel => Sel(1), Y => Y5);
+
+    -- Final layer of 2×1 multiplexer
+    MUX6 : mux_2x1 Port Map (A => Y4, B => Y5, Sel => Sel(2), Y => Y);
+
+end Structural;

--- a/Codes to learn from/4-general stuff/mux_Mx1_Nbit.vhd
+++ b/Codes to learn from/4-general stuff/mux_Mx1_Nbit.vhd
@@ -1,0 +1,50 @@
+ibrary IEEE;
+use IEEE.STD_LOGIC_1164.ALL;
+use IEEE.math_real.all;
+
+entity MuxMx1Nb is
+    generic (
+        N : integer := 8;
+        M : integer := 16
+    );
+    port (
+        I : in  STD_LOGIC_VECTOR(M*N-1 downto 0);
+        S : in  STD_LOGIC_VECTOR(integer(ceil(log2(real(M))))-1 downto 0);
+        Y : out STD_LOGIC_VECTOR(N-1 downto 0)
+    );
+end MuxMx1Nb;
+
+architecture structural of MuxMx1Nb is
+    component MUX2X1
+        generic (N : integer := 8);
+        port (
+            A : in  STD_LOGIC_VECTOR(N-1 downto 0);
+            B : in  STD_LOGIC_VECTOR(N-1 downto 0);
+            S : in  STD_LOGIC;
+            Y : out STD_LOGIC_VECTOR(N-1 downto 0)
+        );
+    end component;
+
+    constant stages : integer := integer(ceil(log2(real(M))));
+    type stage_array is array (0 to stages) of STD_LOGIC_VECTOR(M*N-1 downto 0);
+    signal Y_stage : stage_array;
+
+begin
+
+    Y_stage(0) <= I;
+
+    gen_stage : for i in 0 to stages-1 generate
+        gen_mux : for j in 0 to (M / (2**(i+1)))-1 generate
+            mux2x1_inst : MUX2X1
+                generic map (N => N)
+                port map (
+                    A => Y_stage(i)((2*j+1)*N-1 downto 2*j*N),   
+                    B => Y_stage(i)((2*j+2)*N-1 downto (2*j+1)*N), 
+                    S => S(i),                                   
+                    Y => Y_stage(i+1)((j+1)*N-1 downto j*N)      
+                );
+        end generate;
+    end generate;
+
+    Y <= Y_stage(stages)(N-1 downto 0);
+end structural;

--- a/Codes to learn from/5-project/parity_checker.vhd
+++ b/Codes to learn from/5-project/parity_checker.vhd
@@ -1,0 +1,31 @@
+library IEEE;
+use IEEE.STD_LOGIC_1164.ALL;
+
+entity Parity_Checker_XOR is
+    generic(
+        N : integer := 8
+    );
+    Port (
+        data_in   : in  STD_LOGIC_VECTOR(N-1 downto 0); 
+        selects    : in  STD_LOGIC;               
+        parity_out : out STD_LOGIC                  
+    );
+end Parity_Checker_XOR;
+
+architecture Behavioral of Parity_Checker_XOR is
+begin
+    process(data_in,selects)
+    variable i :     integer;
+    variable result: std_logic;
+    begin
+      result := data_in(0);
+    for i in 1 to N-1 loop
+      result := result xor data_in(i);
+    end loop;
+      if selects = '0' then 
+      parity_out <= NOT result; 
+      else 
+         parity_out <= result; 
+    end if;
+    end process;
+end Behavioral;


### PR DESCRIPTION
- Added VHDL code for a Parity Checker with selectable parity output (even or odd).
- Implemented an 8-to-1 Multiplexer using structural design with hierarchical 2-to-1 MUX components.
- Added a generic M-to-1 Multiplexer with N-bit data width using an iterative structural approach.

New files:
  - parity_checker.vhd
  - mux_8x1_structural.vhd
  - mux_Mx1_Nbit.vhd